### PR TITLE
Change Sender module target url and json-content

### DIFF
--- a/source/modules/sender.js
+++ b/source/modules/sender.js
@@ -2,6 +2,8 @@
 
 const request = require("request");
 
+var sender_conf = require("./sender_config");
+
 /**
  * Sender of transformed data in api
  * @class Sender
@@ -32,16 +34,8 @@ class Sender {
      * @memberOf Sender
      */
     send(data, callback) {
-      //const url = "https://apinf.io/rest/v1/apis",
-      //const url = "https://nightly.apinf.io/rest/v1/apis",
-      const url = "http://localhost:3000/rest/v1/apis",
+      const url = sender_conf.send_apis_url,
             json = {
-                // api: {
-                //     id: this._guid(),
-                //     name: data.title,
-                //     description: data.description,
-                //     api_endpoint_url: data.endpoint
-                // }
                 name: data.title,
                 description: data.description,
                 url: data.endpoint

--- a/source/modules/sender.js
+++ b/source/modules/sender.js
@@ -22,7 +22,7 @@ class Sender {
 
         return `${s4()}${s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`;
     }
-    
+
     /**
      * Send transformed data in api
      * @public
@@ -32,16 +32,21 @@ class Sender {
      * @memberOf Sender
      */
     send(data, callback) {
-        const url = "https://apinf.io/apis",
+      //const url = "https://apinf.io/rest/v1/apis",
+      //const url = "https://nightly.apinf.io/rest/v1/apis",
+      const url = "http://localhost:3000/rest/v1/apis",
             json = {
-                api: {
-                    id: this._guid(),
-                    name: data.title,
-                    description: data.description,
-                    api_endpoint_url: data.endpoint
-                }
+                // api: {
+                //     id: this._guid(),
+                //     name: data.title,
+                //     description: data.description,
+                //     api_endpoint_url: data.endpoint
+                // }
+                name: data.title,
+                description: data.description,
+                url: data.endpoint
             };
-        
+
         request.post(
             url,
             {

--- a/source/modules/sender_config.json
+++ b/source/modules/sender_config.json
@@ -1,0 +1,3 @@
+{
+  "send_apis_url": "http://localhost:3000/rest/v1/apis"
+}


### PR DESCRIPTION
Closes #8 

To integrate the API-Harvester to the APInf.io platform, sender module target url and json content header names need to be changed.